### PR TITLE
Adding way to start critter using env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ ADD             target/critter-*-pkg.tar.gz   /opt/critter
 RUN             chmod a+x -R /opt/critter/bin
 
 EXPOSE          8888 8877
-CMD             ["/opt/critter/bin/start.sh","--no-daemon"]
+CMD             ["/opt/critter/bin/start-container.sh","--no-daemon"]
 

--- a/package/bin/start-container.sh
+++ b/package/bin/start-container.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Critter service startup script that can be used inside a Docker container.
+#
+# uses environment properties to configure Critter
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+java \
+    -Dlog4j.configuration="file://$DIR/../conf/log4j.properties" \
+    $JAVA_OPTS \
+    -classpath "$DIR/../lib/*" \
+    com.philemonworks.critter.Launcher

--- a/src/main/java/com/philemonworks/critter/Launcher.java
+++ b/src/main/java/com/philemonworks/critter/Launcher.java
@@ -26,6 +26,7 @@ public class Launcher {
 	
     public static void main(String[] args) {
     	if (args.length == 0) {
+            System.out.println("No argument given - reading form environment variables");
             startWithConfiguration(createPropertiesFromEnv());
     		return;
     	}
@@ -39,7 +40,7 @@ public class Launcher {
         final TrafficManager manager = new TrafficManager();
         Module managerModule = new ManagerModule(new Properties(configProperties), manager);
         LOG.info("Starting Proxy Server...");
-        LOG.debug("using the following properties : " + configProperties.toString());
+        LOG.info("using the following properties : " + configProperties.toString());
         final HttpServer proxyServer = startProxyServer(new Properties(configProperties), managerModule);
         Module proxyServerModule = new AbstractModule() {
             protected void configure() {


### PR DESCRIPTION
The four properties set in the conf can now also be set in the environment.
They will default to the settigns in the provided conf file.

The start script for docker containers is now in its own script sending the logs to
the docker log output.

Change-Id: I767fa925323162b3b981ce21c99ea4a9b95d60a8